### PR TITLE
Final update for 1.26

### DIFF
--- a/XD5_Inventory.ps1
+++ b/XD5_Inventory.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 3.0
+﻿#Requires -Version 3.0
 #This File is in Unicode format.  Do not edit in an ASCII editor.
 
 #region help text
@@ -24,14 +24,14 @@
 		Policies
 		Hosts
 
-	Using the MachineCatalogs parameter can cause the report to take a very long time to complete and
-	can generate an extremely long report.
+	Using the MachineCatalogs parameter can cause the report to take a very long time to 
+	complete and can generate an extremely long report.
 	
-	Using the DeliveryGroups parameter can cause the report to take a very long time to complete and
-	can generate an extremely long report.
+	Using the DeliveryGroups parameter can cause the report to take a very long time to 
+	complete and can generate an extremely long report.
 
-	Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to take an
-	extremely long time to complete and generate an exceptionally long report.
+	Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to 
+	take an extremely long time to complete and generate an exceptionally long report.
 
 	Creates an output file named after the XenDesktop 5.x Site.
 	Word and PDF Documents include a Cover Page, Table of Contents and Footer.
@@ -49,15 +49,38 @@
 		Spanish
 		Swedish
 		
-.PARAMETER CompanyName
-	Company Name to use for the Cover Page.  
-	Default value is contained in HKCU:\Software\Microsoft\Office\Common\UserInfo\CompanyName or
-	HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated on the 
-	computer running the script.
-	This parameter has an alias of CN.
-	If either registry key does not exist and this parameter is not specified, the report will
-	not contain a Company Name on the cover page.
-	This parameter is only valid with the MSWORD and PDF output parameters.
+.PARAMETER HTML
+	Creates an HTML file with an .html extension.
+	This parameter is disabled by default.
+.PARAMETER MSWord
+	SaveAs DOCX file
+	This parameter is set True if no other output format is selected.
+.PARAMETER PDF
+	SaveAs PDF file instead of DOCX file.
+	This parameter is disabled by default.
+	The PDF file is roughly 5X to 10X larger than the DOCX file.
+	This parameter requires Microsoft Word to be installed.
+	This parameter uses the Word SaveAs PDF capability.
+.PARAMETER Text
+	Creates a formatted text file with a .txt extension.
+	This parameter is disabled by default.
+.PARAMETER AddDateTime
+	Adds a date time stamp to the end of the file name.
+	Time stamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
+	This parameter is disabled by default.
+	This parameter has an alias of ADT.
+.PARAMETER AdminAddress
+	Specifies the address of a XenDesktop controller the PowerShell snapins will connect 
+	to. 
+	This can be provided as a host name or an IP address. 
+	This parameter defaults to LocalHost.
+	This parameter has an alias of AA.
+.PARAMETER Applications
+	Gives detailed information for all applications.
+	This parameter is disabled by default.
+	This parameter has an alias of Apps.
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.  
 		The following Cover Pages have an Address field:
@@ -85,6 +108,16 @@
 			Exposure (Word 2010)
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CF.
+.PARAMETER CompanyName
+	Company Name to use for the Cover Page.  
+	Default value is contained in 
+	HKCU:\Software\Microsoft\Office\Common\UserInfo\CompanyName or
+	HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated 
+	on the computer running the script.
+	This parameter has an alias of CN.
+	If either registry key does not exist and this parameter is not specified, the report 
+	will not contain a Company Name on the cover page.
+	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER CompanyPhone
 	Company Phone to use for the Cover Page, if the Cover Page has the Phone field.  
 		The following Cover Pages have a Phone field:
@@ -96,14 +129,14 @@
 	What Microsoft Word Cover Page to use.
 	Only Word 2010, 2013 and 2016 are supported.
 	(default cover pages in Word en-US)
-	
+
 	Valid input is:
 		Alphabet (Word 2010. Works)
 		Annual (Word 2010. Doesn't work well for this report)
 		Austere (Word 2010. Works)
-		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly works in 2010 but 
-						Subtitle/Subject & Author fields need to be moved 
-						after title box is moved up)
+		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
+		works in 2010 but Subtitle/Subject & Author fields need to be moved 
+		after title box is moved up)
 		Banded (Word 2013/2016. Works)
 		Conservative (Word 2010. Works)
 		Contrast (Word 2010. Works)
@@ -113,20 +146,22 @@
 		Filigree (Word 2013/2016. Works)
 		Grid (Word 2010/2013/2016. Works in 2010)
 		Integral (Word 2013/2016. Works)
-		Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font 
-						changed to 8 point)
-		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font 
-						changed to 8 point)
+		Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
+		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
 		Mod (Word 2010. Works)
-		Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 point)
+		Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+		36 point)
 		Newsprint (Word 2010. Works but date is not populated)
 		Perspective (Word 2010. Works)
 		Pinstripes (Word 2010. Works)
-		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized or font 
-					changed to 14 point)
+		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
+		resized or font changed to 14 point)
 		Retrospect (Word 2013/2016. Works)
 		Semaphore (Word 2013/2016. Works)
-		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
+		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+		2010)
 		Slice (Dark) (Word 2013/2016. Doesn't work)
 		Slice (Light) (Word 2013/2016. Doesn't work)
 		Stacks (Word 2010. Works)
@@ -134,47 +169,12 @@
 		Transcend (Word 2010. Works)
 		ViewMaster (Word 2013/2016. Works)
 		Whisp (Word 2013/2016. Works)
-		
+
 	The default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER UserName
-	User name to use for the Cover Page and Footer.
-	The default value is contained in $env:username
-	This parameter has an alias of UN.
-	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER AdminAddress
-	Specifies the address of a XenDesktop controller the PowerShell snapins will connect to. 
-	This can be provided as a host name or an IP address. 
-	This parameter defaults to LocalHost.
-	This parameter has an alias of AA.
-.PARAMETER PDF
-	SaveAs PDF file instead of DOCX file.
-	This parameter is disabled by default.
-	The PDF file is roughly 5X to 10X larger than the DOCX file.
-	This parameter requires Microsoft Word to be installed.
-	This parameter uses the Word SaveAs PDF capability.
-.PARAMETER Text
-	Creates a formatted text file with a .txt extension.
-	This parameter is disabled by default.
-.PARAMETER MSWord
-	SaveAs DOCX file
-	This parameter is set True if no other output format is selected.
-.PARAMETER HTML
-	Creates an HTML file with an .html extension.
-	This parameter is disabled by default.
-.PARAMETER MachineCatalogs
-	Gives detailed information for all machines in all Machine Catalogs.
-	
-	Using the MachineCatalogs parameter can cause the report to take a very 
-	long time to complete and can generate an extremely long report.
-	
-	Using both the MachineCatalogs and DeliveryGroups parameters can cause 
-	the report to take an extremely long time to complete and generate an 
-	exceptionally long report.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of MC.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
 .PARAMETER DeliveryGroups
 	Gives detailed information for all desktops in all Desktop (Delivery) Groups.
 	
@@ -203,10 +203,48 @@
 	
 	This parameter is disabled by default.
 	This parameter has an alias of DGU.
-.PARAMETER Applications
-	Gives detailed information for all applications.
+.PARAMETER Hardware
+	Use WMI to gather hardware information on: Computer System, Disks, Processor and 
+	Network Interface Cards
+	This parameter may require the script be run from an elevated PowerShell session 
+	using an account with permission to retrieve hardware information (i.e. Domain Admin 
+	or Local Administrator).
+	Selecting this parameter will add to both the time it takes to run the script and 
+	size of the report.
 	This parameter is disabled by default.
-	This parameter has an alias of Apps.
+	This parameter has an alias of HW.
+.PARAMETER Hosting
+	Give detailed information for Hosts.
+	This parameter is disabled by default.
+	This parameter has an alias of Host.
+.PARAMETER MachineCatalogs
+	Gives detailed information for all machines in all Machine Catalogs.
+	
+	Using the MachineCatalogs parameter can cause the report to take a very 
+	long time to complete and can generate an extremely long report.
+	
+	Using both the MachineCatalogs and DeliveryGroups parameters can cause 
+	the report to take an extremely long time to complete and generate an 
+	exceptionally long report.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of MC.
+.PARAMETER NoADPolicies
+	Excludes all Citrix AD based policy information from the output document.
+	Includes only Site policies created in Studio.
+	
+	This switch is useful in large AD environments, where there may be thousands
+	of policies, to keep SYSVOL from being searched.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of NoAD.
+.PARAMETER NoPolicies
+	Excludes all Site and Citrix AD based policy information from the output document.
+	
+	Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of NP.
 .PARAMETER Policies
 	Give detailed information for both Site and Citrix AD based Policies.
 	
@@ -227,42 +265,11 @@
 	
 	This parameter is disabled by default.
 	This parameter has an alias of Pol.
-.PARAMETER NoPolicies
-	Excludes all Site and Citrix AD based policy information from the output document.
-	
-	Using the NoPolicies parameter will cause the Policies parameter to be set to False.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of NP.
-.PARAMETER NoADPolicies
-	Excludes all Citrix AD based policy information from the output document.
-	Includes only Site policies created in Studio.
-	
-	This switch is useful in large AD environments, where there may be thousands
-	of policies, to keep SYSVOL from being searched.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of NoAD.
-.PARAMETER Hosting
-	Give detailed information for Hosts.
-	This parameter is disabled by default.
-	This parameter has an alias of Host.
-.PARAMETER AddDateTime
-	Adds a date time stamp to the end of the file name.
-	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-	This parameter is disabled by default.
-	This parameter has an alias of ADT.
-.PARAMETER Hardware
-	Use WMI to gather hardware information on: Computer System, Disks, Processor and Network Interface Cards
-	This parameter may require the script be run from an elevated PowerShell session 
-	using an account with permission to retrieve hardware information (i.e. Domain Admin or Local Administrator).
-	Selecting this parameter will add to both the time it takes to run the script and size of the report.
-	This parameter is disabled by default.
-	This parameter has an alias of HW.
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
+.PARAMETER UserName
+	User name to use for the Cover Page and Footer.
+	The default value is contained in $env:username
+	This parameter has an alias of UN.
+	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER SmtpServer
 	Specifies the optional email server to send the output report. 
 .PARAMETER SmtpPort
@@ -281,7 +288,8 @@
 	PS C:\PSScript > .\XD5_Inventory.ps1
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -293,7 +301,8 @@
 	PS C:\PSScript > .\XD5_Inventory.ps1 -PDF
 	
 	Will use all default values and save the document as a PDF file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -307,7 +316,8 @@
 	This parameter is reserved for a future update and no output is created at this time.
 	
 	Will use all default values and save the document as a formatted text file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -320,7 +330,8 @@
 	This parameter is reserved for a future update and no output is created at this time.
 	
 	Will use all default values and save the document as an HTML file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -332,7 +343,8 @@
 	
 	Creates a report with full details for all machines in all Machine Catalogs.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -344,7 +356,8 @@
 	
 	Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -356,7 +369,8 @@
 	
 	Creates a report with utilization details for all Desktop (Delivery) Groups.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -369,7 +383,8 @@
 	Creates a report with full details for all machines in all Machine Catalogs and 
 	all desktops in all Desktop (Delivery) Groups.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -381,7 +396,8 @@
 	
 	Creates a report with full details for Hosts.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -393,7 +409,8 @@
 	
 	Creates a report with full details for HDX Policies.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -405,7 +422,8 @@
 	
 	Creates a report with no HDX Policy information.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -417,7 +435,8 @@
 	
 	Creates a report with no Citrix AD based Policy information.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -431,7 +450,8 @@
 	no Citrix AD based Policy information.
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -439,7 +459,8 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XD5_Inventory.ps1 -DeliveryGroups -MachineCatalogs -Hosting -Policies
+	PS C:\PSScript > .\XD5_Inventory.ps1 -DeliveryGroups -MachineCatalogs -Hosting 
+	-Policies
 	
 	Creates a report with full details for all:
 		Machines in all Machine Catalogs
@@ -447,7 +468,8 @@
 		Hosts
 		Policies
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -459,7 +481,8 @@
 	
 	Creates a report with full details for all applications.
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -467,7 +490,8 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript .\XD5_Inventory.ps1 -CompanyName "Carl Webster Consulting" -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
+	PS C:\PSScript .\XD5_Inventory.ps1 -CompanyName "Carl Webster Consulting" 
+	-CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 
 	Will use:
 		Carl Webster Consulting for the Company Name.
@@ -475,7 +499,8 @@
 		Carl Webster for the User Name.
 		Controller named DDC01 for the AdminAddress.
 .EXAMPLE
-	PS C:\PSScript .\XD5_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster"
+	PS C:\PSScript .\XD5_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN 
+	"Carl Webster"
 
 	Will use:
 		Carl Webster Consulting for the Company Name (alias CN).
@@ -483,10 +508,11 @@
 		Carl Webster for the User Name (alias UN).
 		The computer running the script for the AdminAddress.
 .EXAMPLE
-	PS C:\PSScript .\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" `
-	-CoverPage Exposure -UserName "Dr. Watson" `
-	-CompanyAddress "221B Baker Street, London, England" `
-	-CompanyFax "+44 1753 276600" `
+	PS C:\PSScript .\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" 
+	-CoverPage Exposure 
+	-UserName "Dr. Watson" 
+	-CompanyAddress "221B Baker Street, London, England" 
+	-CompanyFax "+44 1753 276600" 
 	-CompanyPhone "+44 1753 276200"
 
 	Will use:
@@ -495,10 +521,11 @@
 		Dr. Watson for the User Name.
 		221B Baker Street, London, England for the Company Address.
 		+44 1753 276600 for the Company Fax.
-		+44 1753 276200 for the Compnay Phone.
+		+44 1753 276200 for the Company Phone.
 .EXAMPLE
 	PS C:\PSScript .\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" `
-	-CoverPage Facet -UserName "Dr. Watson" `
+	-CoverPage Facet 
+	-UserName "Dr. Watson" 
 	-CompanyEmail SuperSleuth@SherlockHolmes.com
 
 	Will use:
@@ -510,7 +537,8 @@
 	PS C:\PSScript > .\XD5_Inventory.ps1 -AddDateTime
 	
 	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -526,7 +554,8 @@
 	PS C:\PSScript > .\XD5_Inventory.ps1 -PDF -AddDateTime
 	
 	Will use all Default values and save the document as a PDF file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -542,7 +571,8 @@
 	PS C:\PSScript > .\XD5_Inventory.ps1 -Hardware
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -553,7 +583,8 @@
 	PS C:\PSScript > .\XD5_Inventory.ps1 -Folder \\FileServer\ShareName
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -563,42 +594,104 @@
 	
 	Output file will be saved in the path \\FileServer\ShareName
 .EXAMPLE
-	PS C:\PSScript > .\XD5_Inventory.ps1 -SmtpServer mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld
-	
-	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	$env:username = Administrator
+	PS C:\PSScript > .\XD5_Inventory.ps1 
+	-SmtpServer mail.domain.tld
+	-From XDAdmin@domain.tld 
+	-To ITGroup@domain.tld	
 
-	Carl Webster for the Company Name.
-	Sideline for the Cover Page format.
-	Administrator for the User Name.
-	
-	Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, sending to ITGroup@domain.tld.
-	If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, 
+	sending to ITGroup@domain.tld.
+
+	The script will use the default SMTP port 25 and will not use SSL.
+
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
 .EXAMPLE
-	PS C:\PSScript > .\XD5_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
-	
-	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	$env:username = Administrator
+	PS C:\PSScript > .\XD5_Inventory.ps1 
+	-SmtpServer mailrelay.domain.tld
+	-From Anonymous@domain.tld 
+	-To ITGroup@domain.tld	
 
-	Carl Webster for the Company Name.
-	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	***SENDING UNAUTHENTICATED EMAIL***
+
+	The script will use the email server mailrelay.domain.tld, sending from 
+	anonymous@domain.tld, sending to ITGroup@domain.tld.
+
+	To send unauthenticated email using an email relay server requires the From email account 
+	to use the name Anonymous.
+
+	The script will use the default SMTP port 25 and will not use SSL.
 	
-	Script will use the email server smtp.office365.com on port 587 using SSL, sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-	If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+	***GMAIL/G SUITE SMTP RELAY***
+	https://support.google.com/a/answer/2956491?hl=en
+	https://support.google.com/a/answer/176600?hl=en
+
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	***GMAIL/G SUITE SMTP RELAY***
+
+	The script will generate an anonymous secure password for the anonymous@domain.tld 
+	account.
+.EXAMPLE
+	PS C:\PSScript > .\XD5_Inventory.ps1 
+	-SmtpServer labaddomain-com.mail.protection.outlook.com
+	-UseSSL
+	-From SomeEmailAddress@labaddomain.com 
+	-To ITGroupDL@labaddomain.com	
+
+	***OFFICE 365 Example***
+
+	https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
+	
+	This uses Option 2 from the above link.
+	
+	***OFFICE 365 Example***
+
+	The script will use the email server labaddomain-com.mail.protection.outlook.com, 
+	sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+
+	The script will use the default SMTP port 25 and will use SSL.
+.EXAMPLE
+	PS C:\PSScript > .\XD5_Inventory.ps1 
+	-SmtpServer smtp.office365.com 
+	-SmtpPort 587
+	-UseSSL 
+	-From Webster@CarlWebster.com 
+	-To ITGroup@CarlWebster.com	
+
+	The script will use the email server smtp.office365.com on port 587 using SSL, 
+	sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
+.EXAMPLE
+	PS C:\PSScript > .\XD5_Inventory.ps1 
+	-SmtpServer smtp.gmail.com 
+	-SmtpPort 587
+	-UseSSL 
+	-From Webster@CarlWebster.com 
+	-To ITGroup@CarlWebster.com	
+
+	*** NOTE ***
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	*** NOTE ***
+	
+	The script will use the email server smtp.gmail.com on port 587 using SSL, 
+	sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
-	No objects are output from this script.  This script creates a Word, PDF, formatted text or HTML document.
+	No objects are output from this script.  This script creates a Word, PDF, formatted text,
+	or HTML document.
 .NOTES
 	NAME: XD5_Inventory.ps1
-	VERSION: 1.25
+	VERSION: 1.26
 	AUTHOR: Carl Webster
-	LASTEDIT: December 17, 2019
+	LASTEDIT: May 9, 2020
 #>
 
 #endregion
@@ -608,31 +701,67 @@
 [CmdletBinding(SupportsShouldProcess = $False, ConfirmImpact = "None", DefaultParameterSetName = "Word") ]
 
 Param(
+	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
+	[Switch]$HTML=$False,
+
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$MSWord=$False,
 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$PDF=$False,
 
 	[parameter(ParameterSetName="Text",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$Text=$False,
 
-	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$HTML=$False,
-
+	[parameter(Mandatory=$False)] 
+	[Alias("ADT")]
+	[Switch]$AddDateTime=$False,
+	
 	[parameter(Mandatory=$False)] 
 	[ValidateNotNullOrEmpty()]
 	[Alias("AA")]
 	[string]$AdminAddress="LocalHost",
 
 	[parameter(Mandatory=$False)] 
-	[Alias("MC")]
-	[Switch]$MachineCatalogs=$False,	
+	[Alias("Apps")]
+	[Switch]$Applications=$False,	
 	
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[Alias("CA")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyAddress="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[Alias("CE")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyEmail="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[Alias("CF")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyFax="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[Alias("CN")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyName="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[Alias("CPh")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CompanyPhone="",
+    
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[Alias("CP")]
+	[ValidateNotNullOrEmpty()]
+	[string]$CoverPage="Sideline", 
+
 	[parameter(Mandatory=$False)] 
 	[Alias("DG")]
 	[Switch]$DeliveryGroups=$False,	
@@ -642,98 +771,51 @@ Param(
 	[Switch]$DeliveryGroupsUtilization=$False,	
 	
 	[parameter(Mandatory=$False)] 
-	[Alias("Apps")]
-	[Switch]$Applications=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Pol")]
-	[Switch]$Policies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("NP")]
-	[Switch]$NoPolicies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("NoAD")]
-	[Switch]$NoADPolicies=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("Host")]
-	[Switch]$Hosting=$False,	
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("ADT")]
-	[Switch]$AddDateTime=$False,
+	[string]$Folder="",
 	
 	[parameter(Mandatory=$False)] 
 	[Alias("HW")]
 	[Switch]$Hardware=$False,
 
 	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
+	[Alias("Host")]
+	[Switch]$Hosting=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("MC")]
+	[Switch]$MachineCatalogs=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NoAD")]
+	[Switch]$NoADPolicies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("NP")]
+	[Switch]$NoPolicies=$False,	
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("Pol")]
+	[Switch]$Policies=$False,	
 	
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CN")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CompanyName="",
-    
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CA")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CompanyAddress="",
-    
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CE")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CompanyEmail="",
-    
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CF")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CompanyFax="",
-    
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CPh")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CompanyPhone="",
-    
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("CP")]
-	[ValidateNotNullOrEmpty()]
-	[string]$CoverPage="Sideline", 
-
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Alias("UN")]
 	[ValidateNotNullOrEmpty()]
 	[string]$UserName=$env:username,
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
+	[parameter(Mandatory=$False)] 
 	[string]$SmtpServer="",
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[parameter(Mandatory=$False)] 
 	[int]$SmtpPort=25,
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[parameter(Mandatory=$False)] 
 	[switch]$UseSSL=$False,
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
+	[parameter(Mandatory=$False)] 
 	[string]$From="",
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
+	[parameter(Mandatory=$False)] 
 	[string]$To=""
 	
 	)
@@ -748,6 +830,21 @@ Param(
 
 # Version 1.0 released to the community on March 2, 2015
 
+#Version 1.26 9-May-2020
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
+#	Change Text output to use [System.Text.StringBuilder]
+#		Updated Functions Line and SaveAndCloseTextDocument
+#	Fix bug in HTML output when using -AddDateTime from creating two HTML files
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
+#	Remove the SMTP parameterset and manually verify the parameters
+#	Reorder the parameters
+#	Update Function SendEmail to handle anonymous unauthenticated email
+#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+#	Update Help Text
+#
 #Version 1.25 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -913,7 +1010,15 @@ Else
 		Write-Verbose "$(Get-Date): Text is $($Text)"
 		Write-Verbose "$(Get-Date): HTML is $($HTML)"
 	}
-	Write-Error "Unable to determine output parameter.  Script cannot continue"
+	Write-Error "
+	`n`n
+	`t`t
+	Unable to determine output parameter.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 If($NoPolicies)
@@ -936,16 +1041,104 @@ If($Folder -ne "")
 		Else
 		{
 			#it exists but it is a file not a folder
-			Write-Error "Folder $Folder is a file, not a folder.  Script cannot continue"
+			Write-Error "
+			`n`n
+			`t`t
+			Folder $Folder is a file, not a folder.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 	}
 	Else
 	{
 		#does not exist
-		Write-Error "Folder $Folder does not exist.  Script cannot continue"
+		Write-Error "
+		`n`n
+		`t`t
+		Folder $Folder does not exist.
+		`n`n
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
+}
+
+If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($From) -and [String]::IsNullOrEmpty($To))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified an SmtpServer but did not include a From or To email address.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($From) -and ![String]::IsNullOrEmpty($To))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified an SmtpServer and a To email address but did not include a From email address.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($To) -and ![String]::IsNullOrEmpty($From))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified an SmtpServer and a From email address but did not include a To email address.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($From) -and ![String]::IsNullOrEmpty($To) -and [String]::IsNullOrEmpty($SmtpServer))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified From and To email addresses but did not include the SmtpServer.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($From) -and [String]::IsNullOrEmpty($SmtpServer))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified a From email address but did not include the SmtpServer.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($To) -and [String]::IsNullOrEmpty($SmtpServer))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified a To email address but did not include the SmtpServer.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
 }
 
 #V1.24  Add check if $Policies -eq $True, see if PowerShell session is elevated
@@ -977,17 +1170,17 @@ If($Policies -eq $True)
 	{
 		#abort script
 		Write-Error "
-		`n
-		`n
-		`tThe Citrix Group Policy module cannot be loaded or found in an elevated PowerShell session.
-		`n
-		`n
-		`tThe Policies parameter was used and this is an elevated PowerShell session.
-		`n
-		`n
-		`tRerun the script from a non-elevated PowerShell session. The script will now close.
-		`n
-		`n"
+		`n`n
+		`t`t
+		The Citrix Group Policy module cannot be loaded or found in an elevated PowerShell session.
+		`n`n
+		`t`t
+		The Policies parameter was used and this is an elevated PowerShell session.
+		`n`n
+		`t`t
+		Rerun the script from a non-elevated PowerShell session. The script will now close.
+		`n`n
+		"
 		Write-Verbose "$(Get-Date): "
 		Exit
 	}
@@ -1007,8 +1200,8 @@ If($MSWord -or $PDF)
 	#http://groovy.codehaus.org/modules/scriptom/1.6.0/scriptom-office-2K3-tlb/apidocs/
 	#http://msdn.microsoft.com/en-us/library/office/aa211923(v=office.11).aspx
 	[int]$wdAlignPageNumberRight = 2
-	[long]$wdColorGray15 = 14277081
-	[long]$wdColorGray05 = 15987699 
+	[int]$wdColorGray15 = 14277081
+	[int]$wdColorGray05 = 15987699 
 	[int]$wdMove = 0
 	[int]$wdSeekMainDocument = 0
 	[int]$wdSeekPrimaryFooter = 4
@@ -1106,7 +1299,7 @@ If($HTML)
 
 If($TEXT)
 {
-	$global:output = ""
+	[System.Text.StringBuilder] $global:Output = New-Object System.Text.StringBuilder( 16384 )
 }
 #endregion
 
@@ -1435,7 +1628,7 @@ Function GetComputerWMIInfo
 				
 				If($? -and $Null -ne $ThisNic)
 				{
-					OutputNicItem $Nic $ThisNic
+					OutputNicItem $Nic $ThisNic $RemoteComputerName
 				}
 				ElseIf(!$?)
 				{
@@ -1859,9 +2052,9 @@ Function OutputProcessorItem
 
 Function OutputNicItem
 {
-	Param([object]$Nic, [object]$ThisNic)
+	Param([object]$Nic, [object]$ThisNic, [string]$RemoteComputerName)
 	
-	$powerMgmt = Get-WmiObject MSPower_DeviceEnable -Namespace root\wmi | where {$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	$powerMgmt = Get-WmiObject -computername $RemoteComputerName MSPower_DeviceEnable -Namespace root\wmi | Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
 
 	If($? -and $Null -ne $powerMgmt)
 	{
@@ -1880,26 +2073,48 @@ Function OutputNicItem
 	}
 	
 	$xAvailability = ""
-	Switch ($processor.availability)
+	Switch ($ThisNic.availability)
 	{
-		1	{$xAvailability = "Other"; Break}
-		2	{$xAvailability = "Unknown"; Break}
-		3	{$xAvailability = "Running or Full Power"; Break}
-		4	{$xAvailability = "Warning"; Break}
-		5	{$xAvailability = "In Test"; Break}
-		6	{$xAvailability = "Not Applicable"; Break}
-		7	{$xAvailability = "Power Off"; Break}
-		8	{$xAvailability = "Off Line"; Break}
-		9	{$xAvailability = "Off Duty"; Break}
-		10	{$xAvailability = "Degraded"; Break}
-		11	{$xAvailability = "Not Installed"; Break}
-		12	{$xAvailability = "Install Error"; Break}
-		13	{$xAvailability = "Power Save - Unknown"; Break}
-		14	{$xAvailability = "Power Save - Low Power Mode"; Break}
-		15	{$xAvailability = "Power Save - Standby"; Break}
-		16	{$xAvailability = "Power Cycle"; Break}
-		17	{$xAvailability = "Power Save - Warning"; Break}
+		1		{$xAvailability = "Other"; Break}
+		2		{$xAvailability = "Unknown"; Break}
+		3		{$xAvailability = "Running or Full Power"; Break}
+		4		{$xAvailability = "Warning"; Break}
+		5		{$xAvailability = "In Test"; Break}
+		6		{$xAvailability = "Not Applicable"; Break}
+		7		{$xAvailability = "Power Off"; Break}
+		8		{$xAvailability = "Off Line"; Break}
+		9		{$xAvailability = "Off Duty"; Break}
+		10		{$xAvailability = "Degraded"; Break}
+		11		{$xAvailability = "Not Installed"; Break}
+		12		{$xAvailability = "Install Error"; Break}
+		13		{$xAvailability = "Power Save - Unknown"; Break}
+		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15		{$xAvailability = "Power Save - Standby"; Break}
+		16		{$xAvailability = "Power Cycle"; Break}
+		17		{$xAvailability = "Power Save - Warning"; Break}
 		Default	{$xAvailability = "Unknown"; Break}
+	}
+
+	#attempt to get Receive Side Scaling setting
+	$RSSEnabled = "N/A"
+	Try
+	{
+		#https://ios.developreference.com/article/10085450/How+do+I+enable+VRSS+(Virtual+Receive+Side+Scaling)+for+a+Windows+VM+without+relying+on+Enable-NetAdapterRSS%3F
+		$RSSEnabled = (Get-WmiObject -ComputerName $RemoteComputerName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0).Enabled
+
+		If($RSSEnabled)
+		{
+			$RSSEnabled = "Enabled"
+		}
+		ELse
+		{
+			$RSSEnabled = "Disabled"
+		}
+	}
+	
+	Catch
+	{
+		$RSSEnabled = "Not available on $Script:RunningOS"
 	}
 
 	$xIPAddress = @()
@@ -1978,6 +2193,7 @@ Function OutputNicItem
 		}
 		$NicInformation += @{ Data = "Availability"; Value = $xAvailability; }
 		$NicInformation += @{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }
+		$NicInformation += @{ Data = "Receive Side Scaling"; Value = $RSSEnabled; }
 		$NicInformation += @{ Data = "Physical Address"; Value = $Nic.macaddress; }
 		If($xIPAddress.Count -gt 1)
 		{
@@ -2088,6 +2304,7 @@ Function OutputNicItem
 		Line 2 "Availability`t`t: " $xAvailability
 		Line 2 "Allow computer to turn "
 		Line 2 "off device to save power: " $PowerSaving
+		Line 2 "Receive Side Scaling`t: " $RSSEnabled
 		Line 2 "Physical Address`t: " $nic.macaddress
 		Line 2 "IP Address`t`t: " $xIPAddress[0]
 		$cnt = -1
@@ -2187,6 +2404,7 @@ Function OutputNicItem
 		}
 		$rowdata += @(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))
 		$rowdata += @(,('Allow the computer to turn off this device to save power',($htmlsilver -bor $htmlbold),$PowerSaving,$htmlwhite))
+		$rowdata += @(,('Receive Side Scaling',($htmlsilver -bor $htmlbold),$RSSEnabled,$htmlwhite))
 		$rowdata += @(,('Physical Address',($htmlsilver -bor $htmlbold),$Nic.macaddress,$htmlwhite))
 		$rowdata += @(,('IP Address',($htmlsilver -bor $htmlbold),$xIPAddress[0],$htmlwhite))
 		$cnt = -1
@@ -2782,7 +3000,15 @@ Function SetupWord
 	{
 		Write-Warning "The Word object could not be created.  You may need to repair your Word installation."
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tThe Word object could not be created.  You may need to repair your Word installation.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		The Word object could not be created.  You may need to repair your Word installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
 
@@ -2799,7 +3025,15 @@ Function SetupWord
 	If(!($Script:WordLanguageValue -gt -1))
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tUnable to determine the Word language value.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Unable to determine the Word language value.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 	Write-Verbose "$(Get-Date): Word language value is $($Script:WordLanguageValue)"
@@ -2824,13 +3058,45 @@ Function SetupWord
 	ElseIf($Script:WordVersion -eq $wdWord2007)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tMicrosoft Word 2007 is no longer supported.`n`n`t`tScript will end.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Microsoft Word 2007 is no longer supported.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		"
 		AbortScript
+	}
+	ElseIf($Script:WordVersion -eq 0)
+	{
+		Write-Error "
+		`n`n
+		`t`t
+		The Word Version is 0. You should run a full online repair of your Office installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
+		Exit
 	}
 	Else
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tYou are running an untested or unsupported version of Microsoft Word.`n`n`t`tScript will end.`n`n`t`tPlease send info on your version of Word to webster@carlwebster.com`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		You are running an untested or unsupported version of Microsoft Word.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		`t`t
+		Please send info on your version of Word to webster@carlwebster.com
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -2972,7 +3238,15 @@ Function SetupWord
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Verbose "$(Get-Date): Word language value $($Script:WordLanguageValue)"
 		Write-Verbose "$(Get-Date): Culture code $($Script:WordCultureCode)"
-		Write-Error "`n`n`t`tFor $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		For $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3035,7 +3309,15 @@ Function SetupWord
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn empty Word document could not be created.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An empty Word document could not be created.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3044,7 +3326,15 @@ Function SetupWord
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn unknown error happened selecting the entire Word document for default formatting options.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An unknown error happened selecting the entire Word document for default formatting options.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3218,21 +3508,35 @@ Function Get-RegistryValue($path, $name)
 #region word, text and html line output functions
 Function line
 #function created by Michael B. Smith, Exchange MVP
-#@essentialexchange on Twitter
-#http://TheEssentialExchange.com
+#@essentialexch on Twitter
+#https://essential.exchange/blog
 #for creating the formatted text report
 #created March 2011
 #updated March 2014
+# updated March 2019 to use StringBuilder (about 100 times more efficient than simple strings)
 {
-	Param( [int]$tabs = 0, [string]$name = '', [string]$value = '', [string]$newline = "`r`n", [switch]$nonewline )
-	While( $tabs -gt 0 ) { $Global:Output += "`t"; $tabs--; }
+	Param
+	(
+		[Int]    $tabs = 0, 
+		[String] $name = '', 
+		[String] $value = '', 
+		[String] $newline = [System.Environment]::NewLine, 
+		[Switch] $nonewline
+	)
+
+	while( $tabs -gt 0 )
+	{
+		$null = $global:Output.Append( "`t" )
+		$tabs--
+	}
+
 	If( $nonewline )
 	{
-		$Global:Output += $name + $value
+		$null = $global:Output.Append( $name + $value )
 	}
 	Else
 	{
-		$Global:Output += $name + $value + $newline
+		$null = $global:Output.AppendLine( $name + $value )
 	}
 }
 	
@@ -3841,11 +4145,6 @@ Function CheckHTMLColor
 Function SetupHTML
 {
 	Write-Verbose "$(Get-Date): Setting up HTML"
-    If($AddDateTime)
-    {
-		$Script:FileName1 += "_$(Get-Date -f yyyy-MM-dd_HHmm).html"
-    }
-
     $htmlhead = "<html><head><meta http-equiv='Content-Language' content='da'><title>" + $Title + "</title></head><body>"
     #echo $htmlhead > $FileName1
 	out-file -FilePath $FileName1 -Force -InputObject $HTMLHead 4>$Null
@@ -4167,7 +4466,7 @@ Function SetWordCellFormat
 		# Font size
 		[Parameter()] [ValidateNotNullOrEmpty()] [int] $Size = 0,
 		# Cell background color
-		[Parameter()] [AllowNull()] $BackgroundColor = $Null,
+		[Parameter()] [AllowNull()] [int]$BackgroundColor = $Null,
 		# Force solid background color
 		[Switch] $Solid,
 		[Switch] $Bold,
@@ -4480,7 +4779,7 @@ Function SaveandCloseTextDocument
 		$Script:FileName1 += "_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 	}
 
-	Write-Output $Global:Output | Out-File $Script:Filename1 4>$Null
+	Write-Output $global:Output.ToString() | Out-File $Script:Filename1 4>$Null
 }
 
 Function SaveandCloseHTMLDocument
@@ -4726,73 +5025,126 @@ Function OutputWarning
 }
 #endregion
 
-#region email function
+#region email function#region email function
 Function SendEmail
 {
-	Param([string]$Attachments)
+	Param([array]$Attachments)
 	Write-Verbose "$(Get-Date): Prepare to email"
+
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
 	$emailBody = @"
 Hello, <br />
 <br />
 $Script:Title is attached.
+
 "@ 
 
+	If($Dev)
+	{
+		Out-File -FilePath $Script:DevErrorFile -InputObject $error 4>$Null
+	}
+
 	$error.Clear()
-	If($UseSSL)
+	
+	If($From -Like "anonymous@*")
 	{
-		Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-		-UseSSL *>$Null
-	}
-	Else
-	{
-		Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
-	}
+		#https://serverfault.com/questions/543052/sending-unauthenticated-mail-through-ms-exchange-with-powershell-windows-server
+		$anonUsername = "anonymous"
+		$anonPassword = ConvertTo-SecureString -String "anonymous" -AsPlainText -Force
+		$anonCredentials = New-Object System.Management.Automation.PSCredential($anonUsername,$anonPassword)
 
-	$e = $error[0]
-
-	If($e.Exception.ToString().Contains("5.7.57"))
-	{
-		#The server response was: 5.7.57 SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-		Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
-
-		$emailCredentials = Get-Credential -Message "Enter the email account and password to send email"
-
-		$error.Clear()
 		If($UseSSL)
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-UseSSL -credential $emailCredentials *>$Null 
+			-UseSSL -credential $anonCredentials *>$Null 
 		}
 		Else
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-credential $emailCredentials *>$Null 
+			-credential $anonCredentials *>$Null 
 		}
-
-		$e = $error[0]
-
-		If($? -and $Null -eq $e)
+		
+		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+			Write-Verbose "$(Get-Date): Email successfully sent using anonymous credentials"
 		}
-		Else
+		ElseIf(!$?)
 		{
+			$e = $error[0]
+
 			Write-Verbose "$(Get-Date): Email was not sent:"
 			Write-Warning "$(Get-Date): Exception: $e.Exception" 
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): Email was not sent:"
-		Write-Warning "$(Get-Date): Exception: $e.Exception" 
+		If($UseSSL)
+		{
+			Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+			-UseSSL *>$Null
+		}
+		Else
+		{
+			Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
+		}
+
+		If(!$?)
+		{
+			$e = $error[0]
+			
+			#error 5.7.57 is O365 and error 5.7.0 is gmail
+			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
+			{
+				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
+				Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
+
+				If($Dev)
+				{
+					Out-File -FilePath $Script:DevErrorFile -InputObject $error -Append 4>$Null
+				}
+
+				$error.Clear()
+
+				$emailCredentials = Get-Credential -UserName $From -Message "Enter the password to send email"
+
+				If($UseSSL)
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-UseSSL -credential $emailCredentials *>$Null 
+				}
+				Else
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-credential $emailCredentials *>$Null 
+				}
+
+				If($?)
+				{
+					Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+				}
+				ElseIf(!$?)
+				{
+					$e = $error[0]
+
+					Write-Verbose "$(Get-Date): Email was not sent:"
+					Write-Warning "$(Get-Date): Exception: $e.Exception" 
+				}
+			}
+			Else
+			{
+				Write-Verbose "$(Get-Date): Email was not sent:"
+				Write-Warning "$(Get-Date): Exception: $e.Exception" 
+			}
+		}
 	}
 }
 #endregion
@@ -12711,7 +13063,18 @@ Function ProcessScriptSetup
 	{
 		#We're missing Citrix Snapins that we need
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tMissing Citrix PowerShell Snap-ins Detected, check the console above for more information.`n`n`t`tAre you sure you are running this script on a XenDesktop 5.x Server?`n`n`t`tScript will now close."
+		Write-Error "
+		`n`n
+		`t`t
+		Missing Citrix PowerShell Snap-ins Detected, check the console above for more information.
+		`n`n
+		`t`t
+		Are you sure you are running this script on a XenDesktop 5.x Server?
+		`n`n
+		`t`t
+		Script will now close.
+		`n`n
+		"
 		Break
 	}
 
@@ -12720,19 +13083,25 @@ Function ProcessScriptSetup
 	{
 		Write-Warning "The Citrix Group Policy module Citrix.GroupPolicy.Commands.psm1 could not be loaded `n
 		Please see the Prerequisites section in the ReadMe file (https://dl.dropboxusercontent.com/u/43555945/XD7_Inventory_V1_ReadMe.rtf). 
-		`nCitrix Policy documentation will not take place"
+		`n`n
+		Citrix Policy documentation will not take place"
 		Write-Verbose "$(Get-Date): "
 		$Global:DoPolicies = $False
 	}
 	If(!(Check-LoadedModule "Citrix.GroupPolicy.Commands") -and $Policies -eq $True)
 	{
-		Write-Error "The Citrix Group Policy module Citrix.GroupPolicy.Commands.psm1 could not be loaded 
-		`nPlease see the Prerequisites section in the ReadMe file (https://dl.dropboxusercontent.com/u/43555945/XD7_Inventory_V1_ReadMe.rtf). 
-		`n
-		`n
-		`t`tBecause the Policies parameter was used the script will now close.
-		`n
-		`n"
+		Write-Error "
+		`n`n
+		`t`t
+		The Citrix Group Policy module Citrix.GroupPolicy.Commands.psm1 could not be loaded 
+		`n`n
+		`t`t
+		Please see the Prerequisites section in the ReadMe file (https://dl.dropboxusercontent.com/u/43555945/XD7_Inventory_V1_ReadMe.rtf). 
+		`n`n
+		`t`t
+		Because the Policies parameter was used the script will now close.
+		`n`n
+		"
 		Write-Verbose "$(Get-Date): "
 		Break
 	}
@@ -12764,7 +13133,12 @@ Function ProcessScriptSetup
 	{
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Warning "XenDesktop Site information could not be retrieved.  Script cannot continue"
-		Write-Error "cmdlet failed $($error[ 0 ].ToString())"
+		Write-Error "
+		`n`n
+		`t`t
+		cmdlet failed $($error[ 0 ].ToString())
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -12774,7 +13148,12 @@ Function ProcessScriptSetup
 	{
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Warning "XenDesktop Controller information could not be retrieved.  Script cannot continue"
-		Write-Error "cmdlet failed $($error[ 0 ].ToString())"
+		Write-Error "
+		`n`n
+		`t`t
+		cmdlet failed $($error[ 0 ].ToString())
+		`n`n
+		"
 		AbortScript
 	}
 

--- a/XD5_Inventory_V1_ReadMe.rtf
+++ b/XD5_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -35,8 +35,8 @@
 {\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
 {\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
 {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\red43\green87\blue154;\red230\green230\blue230;\red54\green95\blue145;\red79\green129\blue189;}
-{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
+\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\red43\green87\blue154;\red230\green230\blue230;\red96\green94\blue92;\red225\green223\blue221;
+\red54\green95\blue145;\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
 \ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{
 \s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
 heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
@@ -47,47 +47,49 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
-\snext19 \sqformat \spriority1 \styrsid7409283 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf19\chshdng0\chcfpat0\chcbpat20 \sbasedon10 \ssemihidden \sunhideused \styrsid14503865 Mention;}}{\*\listtable{\list\listtemplateid645948268
-\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4
-\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2
-\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
-\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
-\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
-\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
-\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
-\levelindent0{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
-\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid854762\rsid2102847\rsid2194464\rsid2579094\rsid2584542\rsid3830441\rsid5179641\rsid5267713\rsid5902085\rsid5968116\rsid5973967\rsid7409283\rsid10759808
-\rsid10814657\rsid10818058\rsid11488686\rsid12269613\rsid12479275\rsid12801149\rsid13050711\rsid13263212\rsid13853169\rsid13987238\rsid14043942\rsid14233804\rsid14503865\rsid14697282\rsid14959124\rsid15736319\rsid16517051}{\mmathPr\mmathFont34\mbrkBin0
-\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy17\hr15\min31}{\version21}{\edmins126}{\nofpages19}{\nofwords6034}
-{\nofchars34395}{\nofcharsws40349}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\snext19 \sqformat \spriority1 \styrsid7409283 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf19\chshdng0\chcfpat0\chcbpat20 \sbasedon10 \ssemihidden \sunhideused \styrsid14503865 Mention;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
+\cf21\chshdng0\chcfpat0\chcbpat22 \sbasedon10 \ssemihidden \sunhideused \styrsid727653 Unresolved Mention;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
+\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
+{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid727653\rsid854762\rsid2102847\rsid2194464\rsid2579094\rsid2584542\rsid3830441\rsid5179641\rsid5267713\rsid5902085\rsid5968116\rsid5973967\rsid7409283\rsid10759808\rsid10814657
+\rsid10818058\rsid11421811\rsid11488686\rsid12269613\rsid12479275\rsid12801149\rsid13050711\rsid13263212\rsid13853169\rsid13987238\rsid14043942\rsid14233804\rsid14503865\rsid14697282\rsid14959124\rsid15736319\rsid16517051}{\mmathPr\mmathFont34\mbrkBin0
+\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo5\dy9\hr9\min25}{\version22}{\edmins140}{\nofpages21}{\nofwords6267}
+{\nofchars35723}{\nofcharsws41907}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbQ0NLG0NLUwAgJDQyUdpeDU4uLM/DyQAsNaAL0OuGcsAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MbQ0NLG0NLUwAgJDQyUdpeDU4uLM/DyQAqNaAH5dlUwsAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Xen}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
-\b\fs28\cf21\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 Desktop }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid10759808 \hich\af43\dbch\af31505\loch\f43 5}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid16517051 
-\hich\af43\dbch\af31505\loch\f43 .x}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 1}{
-\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf23\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Xen}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
+\b\fs28\cf23\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 Desktop }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf23\insrsid10759808 \hich\af43\dbch\af31505\loch\f43 5}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf23\insrsid16517051 
+\hich\af43\dbch\af31505\loch\f43 .x}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf23\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf23\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 1}{
+\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf23\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5267713 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: This script requires PowerShell V3 or later.
@@ -96,7 +98,7 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 t}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 
 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37  supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 \f37\insrsid5267713 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf24\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 One of the most requested features added to Version 4 was support for non-English versions of Microsoft Word.  The script supports the following languages:
 
@@ -117,7 +119,7 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Spanish
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Swedish
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid12801149 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid12801149 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf24\insrsid12801149 
 \hich\af43\dbch\af31505\loch\f43 Prerequisites
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12801149 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to document anything in a XenDesktop 5.x Site, let us ensure we have the necessary requirements.
@@ -152,7 +154,7 @@ MachineCreation_PowerShellSnapIn_x??
 {\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip" }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid13987238 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bb2000000680074007400700073003a002f002f0064006c002e00640072006f00700062006f007800750073006500720063006f006e00740065006e0074002e0063006f006d002f0075002f0034003300350035003500
-3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c000000000000006900000048}}}{\fldrslt {\rtlch\fcs1 
+3900340035002f004300690074007200690078002e00470072006f007500700050006f006c006900630079002e0043006f006d006d0061006e00640073002e007a00690070000000795881f43b1d7f48af2c825dc485276300000000a5ab0000002c00000000000000690000004800}}}{\fldrslt {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid12801149\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 https://dl.dropboxusercontent.com/u/43555945/Citrix.GroupPolicy.Commands.zip}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid13987238 
@@ -165,7 +167,7 @@ MachineCreation_PowerShellSnapIn_x??
 \i\f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid12801149 
 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
+\f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 . This should be placed\hich\af37\dbch\af31505\loch\f37  on the computer where the script is run.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149 \hich\af37\dbch\af31505\loch\f37 e.\tab}}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149 \hich\af37\dbch\af31505\loch\f37 
 If you are running 64-bit Windows, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid12801149\charrsid12801149 
 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12801149\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -181,12 +183,12 @@ Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrs
  the version that comes with XenApp 6.5. This is an updated }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2579094 \hich\af37\dbch\af31505\loch\f37 version that comes with }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid2579094 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2579094 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab00000000037c0000005400000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid2579094\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab00000000037c000000540000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid2579094\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2579094 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15736319 \hich\af37\dbch\af31505\loch\f37 
   The XenApp 6.5 file is from September 2011 and the updated version is from July 2014.  The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12801149\charrsid12801149 
 
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid12801149 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
+\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf24\insrsid12801149 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf24\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 How to use this script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
@@ -203,8 +205,8 @@ our PowerShell scripts folder.
 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory.ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 
 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
-By default, a Microsoft Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10759808 
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 By default, a Microsoft Word docu
+\hich\af37\dbch\af31505\loch\f37 ment is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10759808 
 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 .x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
 PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10759808 \hich\af37\dbch\af31505\loch\f37 
@@ -239,78 +241,65 @@ _Inventory.ps1 \hich\f37 \endash \loch\f37 full
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid7409283 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid7409283 \hich\af43\dbch\af31505\loch\f43 Help Text}{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid14697282 
+\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid7409283 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf24\insrsid7409283 \hich\af43\dbch\af31505\loch\f43 Help Text}{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf24\insrsid14697282 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7409283 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid7409283 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14503865 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \\\hich\af2\dbch\af31505\loch\f2 
-XD5_Inventory.ps1
+\par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid727653 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XD5_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a C\hich\af2\dbch\af31505\loch\f2 itrix XenDesktop 5.x Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 5.x Site.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \\\hich\af2\dbch\af31505\loch\f2 
-XD5_Inventory.ps1 [-MSWord] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Applications] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-Hosting] [-AddDat\hich\af2\dbch\af31505\loch\f2 eTime]}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2     [-CompanyFax <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XD5_Inventory.ps1 [-MSWord] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-CompanyAddress}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyN\hich\af2\dbch\af31505\loch\f2 ame <String>] [-CompanyPhone <String>]}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Folder <String>] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Hosting]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-Policies] [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpServer <St\hich\af2\dbch\af31505\loch\f2 ring>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \\\hich\af2\dbch\af31505\loch\f2 
-XD5_Inventory.ps1 [-MSWord] [-PDF] [-Text] [-HTML] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [-MachineCatalogs]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XD5_Inventory.ps1 [-HTML] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Folder <St\hich\af2\dbch\af31505\loch\f2 ring>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Hosting] [-MachineCatalogs] [-NoADPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-Policies] [-NoPolicies] [-NoADPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-SmtpServer <String>] [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>]
+\par \hich\af2\dbch\af31505\loch\f2     [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XD5_Inventory.ps1 [-PDF] [-AddDate\hich\af2\dbch\af31505\loch\f2 Time] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-CompanyAddress}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyPhone <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Folder\hich\af2\dbch\af31505\loch\f2  <String>] [-Hardware] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Hosting]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-Policies] [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpServer <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-\hich\af2\dbch\af31505\loch\f2 
-Folder <String>] [-CompanyName <String>] [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2     [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyPhone <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -From \hich\af2\dbch\af31505\loch\f2 <String> -To <String> [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \\\hich\af2\dbch\af31505\loch\f2 
-XD5_Inventory.ps1 [-PDF] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Applications] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-Hosting] [-\hich\af2\dbch\af31505\loch\f2 AddDateTime]}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyAddress <String>] [-CompanyEmail <String>]}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2     [-CompanyFax <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [<CommonParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \\\hich\af2\dbch\af31505\loch\f2 
-XD5_Inventory.ps1 [-Text] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Applications] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2    
-\par \hich\af2\dbch\af31505\loch\f2     [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -NoPolicies] [-NoADPolicies] [-Hosting] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\XD5_Inven\hich\af2\dbch\af31505\loch\f2 tory.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Hosting] [-MachineCatalogs] [-NoADPolicies]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [<Comm\hich\af2\dbch\af31505\loch\f2 onParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 Scripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \\\hich\af2\dbch\af31505\loch\f2 
-XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroups]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Applications] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-NoPolicies] [-NoADPolicies] [-Hosting] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-\hich\af2\dbch\af31505\loch\f2 Folder }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 [-SmtpServer <String>] [-\hich\af2\dbch\af31505\loch\f2 
+SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2     [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
@@ -319,7 +308,7 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Machines
-\par \hich\af2\dbch\af31505\loch\f2         Assign\hich\af2\dbch\af31505\loch\f2 ments
+\par \hich\af2\dbch\af31505\loch\f2         Assignments
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts
@@ -331,27 +320,27 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 complete and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long \hich\af2\dbch\af31505\loch\f2 time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 complete and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 complete and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 can\hich\af2\dbch\af31505\loch\f2  generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 complete and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 take an}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and Deliver\hich\af2\dbch\af31505\loch\f2 yGroups parameters can cause the report to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 take an}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 extremely long time to complete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after th\hich\af2\dbch\af31505\loch\f2 e XenDesktop 5.x Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 5.x Site.
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Documents include a Cover Page, Table of Contents and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
-\par \hich\af2\dbch\af31505\loch\f2         Danish
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Finnish
+\par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -361,6 +350,16 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
@@ -369,23 +368,23 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter require\hich\af2\dbch\af31505\loch\f2 s Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text \hich\af2\dbch\af31505\loch\f2 file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -394,87 +393,30 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, \hich\af2\dbch\af31505\loch\f2 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Positi\hich\af2\dbch\af31505\loch\f2 on?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 to.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShel\hich\af2\dbch\af31505\loch\f2 l snapins will connect }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 to.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This parameter has an alias of AA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                 \hich\af2\dbch\af31505\loch\f2    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Mach\hich\af2\dbch\af31505\loch\f2 ineCatalogs parameter can cause the report to take a very
-\par \hich\af2\dbch\af31505\loch\f2         long time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause
-\par \hich\af2\dbch\af31505\loch\f2         the report to take an extremely long \hich\af2\dbch\af31505\loch\f2 time to complete and generate an
-\par \hich\af2\dbch\af31505\loch\f2         exceptionally long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 fault value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         U\hich\af2\dbch\af31505\loch\f2 sing the DeliveryGroups parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an ext\hich\af2\dbch\af31505\loch\f2 remely long time to complete and generate an
-\par \hich\af2\dbch\af31505\loch\f2         exceptionally long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the d\hich\af2\dbch\af31505\loch\f2 elivery group utilization for however much
-\par \hich\af2\dbch\af31505\loch\f2         utilization data is stored in the database.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The help text for Get-BrokerDesktopUsage says
-\par \hich\af2\dbch\af31505\loch\f2         "Desktop usage information is automatically deleted after 7 days"
-\par \hich\af2\dbch\af31505\loch\f2         but my lab has almost 60\hich\af2\dbch\af31505\loch\f2  days of data.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word or PDF
-\par \hich\af2\dbch\af31505\loch\f2         and requires Excel to be locally installed.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a
-\par \hich\af2\dbch\af31505\loch\f2         longer time to \hich\af2\dbch\af31505\loch\f2 complete and generates a longer report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                \hich\af2\dbch\af31505\loch\f2 False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -485,110 +427,53 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both Pol\hich\af2\dbch\af31505\loch\f2 icies and NoADPolicies results in only policies created in Studio
-\par \hich\af2\dbch\af31505\loch\f2         being in the output document.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default valu\hich\af2\dbch\af31505\loch\f2 e                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Excludes all Site and Citrix AD based policy information from the output document.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has \hich\af2\dbch\af31505\loch\f2 an alias of NP.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2                 The follo\hich\af2\dbch\af31505\loch\f2 wing Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2                         Banded (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                         Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                         Ion \hich\af2\dbch\af31505\loch\f2 (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                         Retrospect (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                         Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                         Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                         ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only vali\hich\af2\dbch\af31505\loch\f2 d with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<Swi\hich\af2\dbch\af31505\loch\f2 tchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from the output document.
-\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policie\hich\af2\dbch\af31505\loch\f2 s, to keep SYSVOL from being searched.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
+\par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have an Emai\hich\af2\dbch\af31505\loch\f2 l field:
+\par \hich\af2\dbch\af31505\loch\f2                         Facet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?                \hich\af2\dbch\af31505\loch\f2     named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts.
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Output filename will be ReportName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 fault value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information\hich\af2\dbch\af31505\loch\f2  on: Computer System, Disks, Processor and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Network Interface Cards
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admi\hich\af2\dbch\af31505\loch\f2 n }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 or Local Administrator).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 size of the report.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2                 The followin\hich\af2\dbch\af31505\loch\f2 g Cover Pages have a Fax field:
+\par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Re\hich\af2\dbch\af31505\loch\f2 quired?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optiona\hich\af2\dbch\af31505\loch\f2 l output folder to save the output report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -596,64 +481,16 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichev\hich\af2\dbch\af31505\loch\f2 er is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 comp\hich\af2\dbch\af31505\loch\f2 uter running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 will}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
-\par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have an Address field:
-\par \hich\af2\dbch\af31505\loch\f2                         Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                         Filigree (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                         Ion (Dark) (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                         Retrospect (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2             Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                         Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                         ViewMaster (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline \hich\af2\dbch\af31505\loch\f2 input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
-\par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2          Facet (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defaul\hich\af2\dbch\af31505\loch\f2 t value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
-\par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have a Fax\hich\af2\dbch\af31505\loch\f2  field:
-\par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
+\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 w}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 ill}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11421811 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 not contain a Company Name on the cover page.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only vali\hich\af2\dbch\af31505\loch\f2 d with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -661,19 +498,19 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for t\hich\af2\dbch\af31505\loch\f2 he Cover Page, if the Cover Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPho\hich\af2\dbch\af31505\loch\f2 ne <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWO\hich\af2\dbch\af31505\loch\f2 RD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
@@ -681,93 +518,90 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
-\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly works }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 in 2010 but}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Subtitle/Subject & Author fields need to be moved}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 after title }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
-\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Work\hich\af2\dbch\af31505\loch\f2 s)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be manually }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be manually }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (W\hich\af2\dbch\af31505\loch\f2 ord 2010/2013/2016. Works if top date is manually changed to 36 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sidelin\hich\af2\dbch\af31505\loch\f2 e (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. \hich\af2\dbch\af31505\loch\f2 Works)
-\par 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Alphabet (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Annual (Word 2010. Doesn't work well for this report)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austere (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject &\hich\af2\dbch\af31505\loch\f2  Author fields need to be moved 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 after title box is moved up)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Banded (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Conservative (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Contrast (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Cubicles (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Exposure (Word 2010. Works if you like looking sideways)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Face\hich\af2\dbch\af31505\loch\f2 t (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Filigree (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Grid (Word 2010/2013/2016. Works in 2010)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Integral (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 manually resized or font changed to 8 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 manually resized or font changed to 8 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Mod (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 36 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Newsprint (Word 2010. Works\hich\af2\dbch\af31505\loch\f2  but date is not populated)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Perspective (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Pinstripes (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 resized or font changed to 14 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Retrospect (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Semaphore (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 2010)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Stacks \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Transcend (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 ViewMaster (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Whisp (Word 2013/2016. Works)}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with\hich\af2\dbch\af31505\loch\f2  the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fals\hich\af2\dbch\af31505\loch\f2 e
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $\hich\af2\dbch\af31505\loch\f2 env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to ta\hich\af2\dbch\af31505\loch\f2 ke an extremely long time to complete and generate an
+\par \hich\af2\dbch\af31505\loch\f2         exceptionally long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Position?               \hich\af2\dbch\af31505\loch\f2      named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for ho\hich\af2\dbch\af31505\loch\f2 wever much
+\par \hich\af2\dbch\af31505\loch\f2         utilization data is stored in the database.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
+\par \hich\af2\dbch\af31505\loch\f2         The help text for Get-BrokerDesktopUsage says
+\par \hich\af2\dbch\af31505\loch\f2         "Desktop usage information is automatically deleted after 7 days"
+\par \hich\af2\dbch\af31505\loch\f2         but my lab has almost 60 days of data.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
-\par \hich\af2\dbch\af31505\loch\f2         The default is 25.
+\par \hich\af2\dbch\af31505\loch\f2         This opt\hich\af2\dbch\af31505\loch\f2 ion is only available when the report is generated in Word or PDF
+\par \hich\af2\dbch\af31505\loch\f2         and requires Excel to be locally installed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a
+\par \hich\af2\dbch\af31505\loch\f2         longer time to complete and generates a longer \hich\af2\dbch\af31505\loch\f2 report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
-\par \hich\af2\dbch\af31505\loch\f2         The default is False.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -775,60 +609,220 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?               \hich\af2\dbch\af31505\loch\f2      false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -To <String>
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer\hich\af2\dbch\af31505\loch\f2  System, Disks, Processor and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Network Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 or Local Administrat\hich\af2\dbch\af31505\loch\f2 or).
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 size of the report.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value           \hich\af2\dbch\af31505\loch\f2      False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs param\hich\af2\dbch\af31505\loch\f2 eter can cause the report to take a very
+\par \hich\af2\dbch\af31505\loch\f2         long time to complete and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause
+\par \hich\af2\dbch\af31505\loch\f2         the report to take an extremely long time to complete \hich\af2\dbch\af31505\loch\f2 and generate an
+\par \hich\af2\dbch\af31505\loch\f2         exceptionally long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy i\hich\af2\dbch\af31505\loch\f2 nformation from the output document.
+\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This paramet\hich\af2\dbch\af31505\loch\f2 er is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD based policy information from the output document.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Note:\hich\af2\dbch\af31505\loch\f2  The Citrix Group Policy PowerShell module will not load from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
+\par \hich\af2\dbch\af31505\loch\f2         If the module is manually imported, the module is not detected from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter \hich\af2\dbch\af31505\loch\f2 can cause the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and pri\hich\af2\dbch\af31505\loch\f2 ority is given to NoPolicies.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both Policies and NoADPolicies results in only policies created in Studio
+\par \hich\af2\dbch\af31505\loch\f2         being in the output document.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?   \hich\af2\dbch\af31505\loch\f2                  false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optio\hich\af2\dbch\af31505\loch\f2 nal email server to send the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <I\hich\af2\dbch\af31505\loch\f2 nt32>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         The default is 25.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         The default is False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         If \hich\af2\dbch\af31505\loch\f2 SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -To <S\hich\af2\dbch\af31505\loch\f2 tring>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariab\hich\af2\dbch\af31505\loch\f2 le, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         Ou\hich\af2\dbch\af31505\loch\f2 tBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word, PDF, formatted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 text or HTML document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this s\hich\af2\dbch\af31505\loch\f2 cript.  This script creates a Word, PDF, formatted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 text,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 
+ or HTML document.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD5_Inventory.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10814657 \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865\charrsid14503865 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.26
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 December 17, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: May 9, 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" o\hich\af2\dbch\af31505\loch\f2 r
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_US\hich\af2\dbch\af31505\loch\f2 ER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer\hich\af2\dbch\af31505\loch\f2  running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script f\hich\af2\dbch\af31505\loch\f2 or the AdminAddress.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
@@ -836,15 +830,17 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Admi\hich\af2\dbch\af31505\loch\f2 nistrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
@@ -854,112 +850,126 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2     This parameter is reserved for a future update and no output is created at this time.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Web\hich\af2\dbch\af31505\loch\f2 ster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sidelin\hich\af2\dbch\af31505\loch\f2 e for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This parameter is reserved for a future update and no output is created at this time.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster\hich\af2\dbch\af31505\loch\f2 " or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------\hich\af2\dbch\af31505\loch\f2 ------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -MachineCatalogs
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.\hich\af2\dbch\af31505\loch\f2 ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates \hich\af2\dbch\af31505\loch\f2 a report with full details for all desktops in all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offic\hich\af2\dbch\af31505\loch\f2 e\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Side\hich\af2\dbch\af31505\loch\f2 line for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -DeliveryGroupsUtilization
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details \hich\af2\dbch\af31505\loch\f2 for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Com\hich\af2\dbch\af31505\loch\f2 panyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $en\hich\af2\dbch\af31505\loch\f2 v:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -DeliveryGroups -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full det\hich\af2\dbch\af31505\loch\f2 ails for all machines in all Machine Catalogs and
-\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
+\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Deskt\hich\af2\dbch\af31505\loch\f2 op (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\S\hich\af2\dbch\af31505\loch\f2 oftware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = \hich\af2\dbch\af31505\loch\f2 Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE \hich\af2\dbch\af31505\loch\f2 9 --------------------------
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -Hosting
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Creates a report with full details for Hosts.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
@@ -968,14 +978,16 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for HDX Policies.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the C\hich\af2\dbch\af31505\loch\f2 over Page format.
+\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 arl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
@@ -984,9 +996,9 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no HDX Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 ="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\S\hich\af2\dbch\af31505\loch\f2 oftware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -994,20 +1006,24 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScrip\hich\af2\dbch\af31505\loch\f2 t >.\\XD5_Inventory.ps1 -NoADPolicies
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPL\hich\af2\dbch\af31505\loch\f2 E 12 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 yName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User \hich\af2\dbch\af31505\loch\f2 Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
@@ -1018,20 +1034,22 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -DeliveryGroups -MachineCatal\hich\af2\dbch\af31505\loch\f2 ogs -Hosting }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -Policies
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 14 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -DeliveryGroups -MachineCatalogs -Hosting }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
@@ -1039,25 +1057,27 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2         Hosts
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a r\hich\af2\dbch\af31505\loch\f2 eport with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl \hich\af2\dbch\af31505\loch\f2 Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     H\hich\af2\dbch\af31505\loch\f2 KEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1065,94 +1085,105 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript .\\XD5_Inventory.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName "Carl}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD5_Inventory.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName "Carl}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster\hich\af2\dbch\af31505\loch\f2  Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl \hich\af2\dbch\af31505\loch\f2 Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD5_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 "Carl Web\hich\af2\dbch\af31505\loch\f2 ster"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript .\\XD5_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Nam\hich\af2\dbch\af31505\loch\f2 e (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 `
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" `
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London,\hich\af2\dbch\af31505\loch\f2  England" `
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600" `
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson" 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England" 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600" 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+4\hich\af2\dbch\af31505\loch\f2 4 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 27\hich\af2\dbch\af31505\loch\f2 6600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compnay Phone.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2     
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 `
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" `
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD5_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Fac\hich\af2\dbch\af31505\loch\f2 et }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson" 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consultin\hich\af2\dbch\af31505\loch\f2 g for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Compnay Email.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Company}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2  Email.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript \hich\af2\dbch\af31505\loch\f2 >.\\XD5_Inventory.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default val\hich\af2\dbch\af31505\loch\f2 ues.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the \hich\af2\dbch\af31505\loch\f2 format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD5SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename wi\hich\af2\dbch\af31505\loch\f2 ll be XD5SiteName_2020-06-01_1800.docx
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -PDF -AddDat\hich\af2\dbch\af31505\loch\f2 eTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -PDF -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Web\hich\af2\dbch\af31505\loch\f2 ster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $e\hich\af2\dbch\af31505\loch\f2 nv:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1160,97 +1191,173 @@ XD5_Inventory.ps1 [-HTML] [-AdminAddress <String>] [-MachineCatalogs] }{\rtlch\f
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD5SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13050711 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD5SiteName_2020-06-01_1800.pdf
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offi\hich\af2\dbch\af31505\loch\f2 ce\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default valu\hich\af2\dbch\af31505\loch\f2 es.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -Folder \\\\FileServer\\Share\hich\af2\dbch\af31505\loch\f2 Name
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\File\hich\af2\dbch\af31505\loch\f2 Server\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -SmtpServer mail.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    PS C:\\PSScript >.\\XD5_Inventory.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Side\hich\af2\dbch\af31505\loch\f2 line for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid10814657 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00038900}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14503865\charrsid13263212 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 , }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to se\hich\af2\dbch\af31505\loch\f2 nd email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default valu\hich\af2\dbch\af31505\loch\f2 es.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Compan\hich\af2\dbch\af31505\loch\f2 y Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 
-\hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10814657 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b560000006d00610069006c0074006f003a00770065006200730074006500720040006300610072006c0077006500620073007400650072002e0063006f006d000000795881f43b1d7f48af2c825dc485276300000000
-a5ab00037200}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14503865\charrsid13263212 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14503865\charrsid14503865 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 
-sending to ITGroup@carlwebster.com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14503865\charrsid14503865 \hich\af2\dbch\af31505\loch\f2 crede\hich\af2\dbch\af31505\loch\f2 ntials.
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
+\par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 https://support.goo
+\hich\af2\dbch\af31505\loch\f2 gle.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The script will generate an anonymous secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     account.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protec\hich\af2\dbch\af31505\loch\f2 tion.outlook.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From SomeEmailAddress@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroupDL@labaddomain.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653 
+{\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
+2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid727653\charrsid727653 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-applicat\hich\af2\dbch\af31505\loch\f2 
+ion-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid727653\charrsid727653 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use\hich\af2\dbch\af31505\loch\f2  the email server labaddomain-com.mail.protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- E\hich\af2\dbch\af31505\loch\f2 XAMPLE 27 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp\hich\af2\dbch\af31505\loch\f2 .office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD5_Inventory.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.gmail.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@Carl\hich\af2\dbch\af31505\loch\f2 Webster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server sm\hich\af2\dbch\af31505\loch\f2 tp.gmail.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -1373,8 +1480,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c04b
-2e4f21b5d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000070f9
+69a30d26d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XD5_Script_ChangeLog.txt
+++ b/XD5_Script_ChangeLog.txt
@@ -3,6 +3,21 @@
 #http://www.CarlWebster.com
 # Created on April 1, 2013
 
+#Version 1.26 9-May-2020
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
+#	Change Text output to use [System.Text.StringBuilder]
+#		Updated Functions Line and SaveAndCloseTextDocument
+#	Fix bug in HTML output when using -AddDateTime from creating two HTML files
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
+#	Remove the SMTP parameterset and manually verify the parameters
+#	Reorder the parameters
+#	Update Function SendEmail to handle anonymous unauthenticated email
+#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+#	Update Help Text
+
 #Version 1.25 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 


### PR DESCRIPTION
#Version 1.26 9-May-2020
#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
#	Add Receive Side Scaling setting to Function OutputNICItem
#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
#	Change Text output to use [System.Text.StringBuilder]
#		Updated Functions Line and SaveAndCloseTextDocument
#	Fix bug in HTML output when using -AddDateTime from creating two HTML files
#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
#	Remove the SMTP parameterset and manually verify the parameters
#	Reorder the parameters
#	Update Function SendEmail to handle anonymous unauthenticated email
#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
#	Update Help Text